### PR TITLE
Repair user retrieving on login

### DIFF
--- a/front/src/components/router/AppRoutes.tsx
+++ b/front/src/components/router/AppRoutes.tsx
@@ -52,6 +52,7 @@ function AppRoutes() {
 									},
 								);
 								userContext.auth.setUpdating(false);
+								userContext.updateUser();
 								navigate('/', { replace: true });
 							} else if (data.state == 'creating') {
 								userContext.auth.setCreating(true);


### PR DESCRIPTION
Before, the user is loaded only if the refresh_token is previously defined and, at login, the informations doesn't appear
Now, on "/callback", the user is retrieved