### PR TITLE
Restart containers on failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         # Anonymous volume. Why ? Because there's platform specific data: /usr/src/app/node_modules volume is initialized from the image
       - /usr/src/app/node_modules
     command: npm run start:dev
-    restart: always
+    restart: on-failure
     depends_on:
       - db
     ports:
@@ -26,7 +26,7 @@ services:
   db:
     image: postgres:latest
     container_name: postgres
-    restart: always
+    restart: on-failure
     env_file:
       - ./back/.env
     networks:
@@ -43,6 +43,7 @@ services:
     depends_on:
       - back
     command: npm run dev
+    restart: on-failure
     ports:
       - 8080:8080
     networks:


### PR DESCRIPTION
Si on veut volontairement stopper un container, on peut pas parce-qu'il se relance automatiquement. Ça m'a l'air mieux de les relancer uniquement quand il y a eu une erreur :ok_hand: 