### PR TITLE
Front/profile - Routing profile & Achievement

### DIFF
--- a/back/src/database/schema.prisma
+++ b/back/src/database/schema.prisma
@@ -70,9 +70,10 @@ model UserProfile {
 }
 
 model UserAchievement {
-    id            Int         @id @unique
+    id            Int             @id @default(autoincrement())
+    type          AchievementType
     unlockedAt    DateTime
-    UserProfile   UserProfile @relation(fields: [userProfileId], references: [id])
+    UserProfile   UserProfile     @relation(fields: [userProfileId], references: [id])
     userProfileId Int
 }
 

--- a/front/src/components/global/Button.tsx
+++ b/front/src/components/global/Button.tsx
@@ -5,7 +5,7 @@ const Button = (props: any) => {
 		<button
 			className="btn"
 			type={props.type}
-			onClick={props.onBtnClick}
+			onClick={props.onClick}
 			style={{
 				...(props.width && { width: `${props.width}` }),
 				...(props.height && { width: `${props.height}` }),

--- a/front/src/components/global/NavBar.tsx
+++ b/front/src/components/global/NavBar.tsx
@@ -24,7 +24,9 @@ function NavBar(props: any) {
 			</ul>
 			<div className="navRight">
 				<img src={userContext.user.profile_picture} />
-				<Link to="/profile">{userContext.user.name}</Link>
+				<Link to={`/profile/${userContext.user.name}`}>
+					{userContext.user.name}
+				</Link>
 				<button className="nav-logout" onClick={userContext.logout}>
 					Logout
 				</button>

--- a/front/src/components/pages/Profile.tsx
+++ b/front/src/components/pages/Profile.tsx
@@ -3,20 +3,27 @@ import MatchHistoryTable from './details/profile/MatchHistoryTable';
 import '@/style/Profile.css';
 import { UserContext } from '@/context/UserContext';
 import React, { useEffect, useState } from 'react';
+import Loader from '../global/Loader';
 import ProfileSummary from './details/profile/ProfileSummary';
 import { back_url } from '@/config.json';
 import { InfoBoxContext, InfoType } from '@/context/InfoBoxContext';
 import { ProfileData, ProfileMatchData } from './details/profile/ProfileTypes';
 import AchievementTable from './details/profile/AchievementTable';
+import { useNavigate, useParams } from 'react-router';
 
 const Profile = () => {
-	const userContext = React.useContext(UserContext);
 	const infoContext = React.useContext(InfoBoxContext);
+	const navigate = useNavigate();
+	const { username } = useParams();
 	const [profile, setProfile] = useState<ProfileData | null>(null);
 
 	function handleSearch(searchValue: string) {
 		if (profile?.name === searchValue || searchValue.length == 0) return;
-		fetch(back_url + `/users/profile/${searchValue}`)
+		navigate(`/profile/${searchValue}`);
+	}
+
+	useEffect(() => {
+		fetch(back_url + `/users/profile/${username}`)
 			.then((response) => {
 				if (response.ok) {
 					return response.json();
@@ -27,20 +34,22 @@ const Profile = () => {
 				setProfile(data);
 			})
 			.catch(() => {
-				infoContext.addInfo({
-					type: InfoType.ERROR,
-					message: `Cannot find or load profile '${searchValue}'`,
-				});
+				if (!profile) navigate('play');
+				else {
+					infoContext.addInfo({
+						type: InfoType.ERROR,
+						message: `Cannot find or load profile '${username}'`,
+					});
+				}
 			});
-	}
+	}, [navigate, username]);
 
-	useEffect(() => {
-		handleSearch(userContext.user.name);
-	}, []);
-
-	if (!profile) return <h2>Profile loading...</h2>;
-
-	return (
+	return !profile ? (
+		<div className="profile-loading">
+			<h2>Profile loading...</h2>
+			<Loader color="black" />
+		</div>
+	) : (
 		<div className="profile-container">
 			<ProfileHeader
 				username={profile.name}

--- a/front/src/components/pages/details/profile/AchievementItem.tsx
+++ b/front/src/components/pages/details/profile/AchievementItem.tsx
@@ -30,7 +30,11 @@ const AchievementItem = (props: AchievementItemProps) => {
 			<ProgressBar
 				width="100%"
 				height="20px"
-				percent={Math.round((props.progress / props.threeshold) * 100)}
+				percent={
+					props.progress > props.threeshold
+						? 100
+						: Math.round((props.progress / props.threeshold) * 100)
+				}
 				text={`${props.progress}/${props.threeshold}`}
 				innerBarColor="rgb(255, 153, 0)"
 			/>

--- a/front/src/components/pages/details/profile/AchievementTable.tsx
+++ b/front/src/components/pages/details/profile/AchievementTable.tsx
@@ -1,5 +1,8 @@
-import { ProfileData, ProfileDataTarget } from './ProfileTypes';
-import { AchievementIdArray } from './ProfileTypes';
+import {
+	AchievementType,
+	ProfileData,
+	ProfileDataTarget,
+} from './ProfileTypes';
 import { AchievementMap } from './Data';
 import AchievementItem from './AchievementItem';
 import '@/style/details/profile/AchievementTable.css';
@@ -14,7 +17,9 @@ const AchievementTable = ({ profile }: AchievementTableProps) => {
 	return (
 		<div className="achievements-table">
 			<h2>
-				{`Achievements (${unlockedAchievement.length}/${AchievementIdArray.length})`}
+				{`Achievements (${unlockedAchievement.length}/${
+					Object.values(AchievementType).length
+				})`}
 			</h2>
 			<hr />
 			<div className="achievements-item-container">
@@ -33,24 +38,22 @@ const AchievementTable = ({ profile }: AchievementTableProps) => {
 	}
 
 	function generateAchievementItem() {
-		const unlockedAchievementId: number[] = profile.achievements.map(
-			(e) => e.id,
-		);
-		const lockedAchievementId: number[] = AchievementIdArray.filter(
-			(id: number) => !unlockedAchievementId.includes(id),
+		const unlockedAchievementType: string[] = profile.achievements.map(
+			(achievement) => achievement.type,
 		);
 
-		//TODO: a bit of code duplication here. Can be done smarter.
+		const lockedAchievementType: string[] = Object.values(
+			AchievementType,
+		).filter((s) => !unlockedAchievementType.includes(s));
+
 		const unlockedAchievement = profile.achievements.map(
 			(achievementData) => {
-				// We're asserting that the database will always return valid ids
-				// (hence the exclamation mark at the end of the next statement;
 				const profileAchievement = AchievementMap.get(
-					achievementData.id,
+					achievementData.type,
 				)!;
 				return (
 					<AchievementItem
-						key={achievementData.id}
+						key={profileAchievement.title}
 						unlocked={true}
 						unlockedDate={new Date(achievementData.unlockedAt)}
 						progress={mapProfileValueToAchievement(
@@ -63,12 +66,12 @@ const AchievementTable = ({ profile }: AchievementTableProps) => {
 			},
 		);
 
-		const lockedAchievement = lockedAchievementId.map((id) => {
-			const profileAchievement = AchievementMap.get(id)!;
+		const lockedAchievement = lockedAchievementType.map((type) => {
+			const profileAchievement = AchievementMap.get(type.toString())!;
 
 			return (
 				<AchievementItem
-					key={id}
+					key={profileAchievement.title}
 					unlocked={false}
 					progress={mapProfileValueToAchievement(
 						profileAchievement.data,

--- a/front/src/components/pages/details/profile/Data.tsx
+++ b/front/src/components/pages/details/profile/Data.tsx
@@ -1,19 +1,19 @@
 import {
 	ProfileAchievement,
 	ProfileDataTarget,
-	AchievementId,
+	AchievementType,
 } from './ProfileTypes';
-import NoviceBall from '@/assets/novice-ball.svg';
-import JackOLanternBall from '@/assets/jack-o-lantern-ball.svg';
-import DiscoBall from '@/assets/disco-ball.svg';
-import RegularBall from '@/assets/regular-ball.svg';
+import NoviceBallIcon from '@/assets/novice-ball.svg';
+import JackOLanternBallIcon from '@/assets/jack-o-lantern-ball.svg';
+import DiscoBallIcon from '@/assets/disco-ball.svg';
+import RegularBallIcon from '@/assets/regular-ball.svg';
 
-export const AchievementMap = new Map<AchievementId, ProfileAchievement>([
+export const AchievementMap = new Map<AchievementType, ProfileAchievement>([
 	[
-		AchievementId.ACH_NEW_SUBJECT,
+		AchievementType.NewSubject,
 		{
 			title: 'New Subject',
-			img: NoviceBall,
+			img: NoviceBallIcon,
 			description: 'Win your first match',
 			earnings: 10,
 			data: ProfileDataTarget.PROFILE_MATCH,
@@ -21,10 +21,10 @@ export const AchievementMap = new Map<AchievementId, ProfileAchievement>([
 		},
 	],
 	[
-		AchievementId.ACH_APPRENTICE_JUGGLER,
+		AchievementType.ApprenticeJuggler,
 		{
 			title: 'Apprentice Juggler',
-			img: RegularBall,
+			img: RegularBallIcon,
 			description: 'Play at least 10 match',
 			earnings: 15,
 			data: ProfileDataTarget.PROFILE_MATCH,
@@ -32,10 +32,10 @@ export const AchievementMap = new Map<AchievementId, ProfileAchievement>([
 		},
 	],
 	[
-		AchievementId.ACH_DAUTING_SUBJECT,
+		AchievementType.DautingSubject,
 		{
 			title: 'Dauting Subject',
-			img: JackOLanternBall,
+			img: JackOLanternBallIcon,
 			description: 'Win at least 20 match',
 			earnings: 42,
 			data: ProfileDataTarget.PROFILE_MATCH_WON,

--- a/front/src/components/pages/details/profile/MatchHistoryRow.tsx
+++ b/front/src/components/pages/details/profile/MatchHistoryRow.tsx
@@ -44,6 +44,7 @@ const MatchHistoryRow = ({ match }: MatchHistoryRowProps) => {
 					userOne={match.userOne}
 					userTwo={match.userTwo}
 					type={match.type}
+					date={new Date(match.createdAt)}
 				/>
 			</CollapseArrow>
 		</div>

--- a/front/src/components/pages/details/profile/MatchHistoryRowDetails.tsx
+++ b/front/src/components/pages/details/profile/MatchHistoryRowDetails.tsx
@@ -11,6 +11,7 @@ interface MatchHistoryRowDetailsProps {
 	userOne: UserMatchData;
 	userTwo: UserMatchData;
 	type: MatchType;
+	date: Date;
 }
 
 interface MatchDetails {
@@ -24,6 +25,7 @@ export function MatchHistoryRowDetails({
 	userOne,
 	userTwo,
 	type,
+	date,
 }: MatchHistoryRowDetailsProps) {
 	// any way to factorise that ?
 	const userDetails: MatchDetails[] = [
@@ -81,7 +83,15 @@ export function MatchHistoryRowDetails({
 				height={30}
 				alt=""
 			/>
-			<h3>{type}</h3>
+			<h3>
+				{`${type} - ${date.toLocaleString('default', {
+					day: '2-digit',
+					month: '2-digit',
+					year: '2-digit',
+					hour: '2-digit',
+					minute: '2-digit',
+				})}`}
+			</h3>
 			<table>
 				<thead></thead>
 				<tbody>

--- a/front/src/components/pages/details/profile/ProfileHeaderSearchBar.tsx
+++ b/front/src/components/pages/details/profile/ProfileHeaderSearchBar.tsx
@@ -7,7 +7,9 @@ const ProfileHeaderSearchBar = (props: any) => {
 	const searchInput = useRef<HTMLInputElement>(null);
 	const [isBtnCliked, setIsBtnClicked] = useState(false);
 
-	function handleSearchButtonClick() {
+	function handleSubmit(e: React.ChangeEvent<HTMLButtonElement>) {
+		e.preventDefault();
+
 		if (!isBtnCliked) {
 			props.onSearchClick(searchInput.current?.value);
 			setIsBtnClicked(true);
@@ -16,18 +18,16 @@ const ProfileHeaderSearchBar = (props: any) => {
 	}
 
 	return (
-		<div className="profile-header-searchbar">
+		<form>
 			<input
 				type="search"
 				ref={searchInput}
 				placeholder="Search for a profile..."
 			/>
-			<Button
-				type="submit"
-				onBtnClick={handleSearchButtonClick}
-				children="Search"
-			/>
-		</div>
+			<Button type="submit" onClick={handleSubmit}>
+				Search
+			</Button>
+		</form>
 	);
 };
 

--- a/front/src/components/pages/details/profile/ProfileTypes.ts
+++ b/front/src/components/pages/details/profile/ProfileTypes.ts
@@ -18,6 +18,7 @@ export interface UserMatchData {
 
 export interface ProfileAchievementData {
 	id: number;
+	type: AchievementType;
 	unlockedAt: string;
 }
 
@@ -47,24 +48,16 @@ export enum ProfileDataTarget {
 	PROFILE_MATCH_WON,
 }
 
-export enum AchievementId {
-	ACH_NEW_SUBJECT = 1,
-	ACH_APPRENTICE_JUGGLER,
-	ACH_DAUTING_SUBJECT,
+export enum AchievementType {
+	NewSubject = 'NEW_SUBJECT',
+	ApprenticeJuggler = 'APPRENTICE_JUGGLER',
+	DautingSubject = 'DAUTING_SUBJECT',
 }
-
-export const AchievementIdArray = [
-	AchievementId.ACH_NEW_SUBJECT,
-	AchievementId.ACH_APPRENTICE_JUGGLER,
-	AchievementId.ACH_DAUTING_SUBJECT,
-];
 
 export enum MatchType {
 	FUN = 'FUN',
 	RANKED = 'RANKED',
 }
-
-export type AchievementIdValue = `${AchievementId}`;
 
 export interface ProfileAchievement {
 	achieveAt?: Date;

--- a/front/src/components/router/AppRoutes.tsx
+++ b/front/src/components/router/AppRoutes.tsx
@@ -142,7 +142,7 @@ function AppRoutes() {
 				<Route index element={<Navigate replace to="play" />} />
 				<Route path="play" element={<Play />} />
 				<Route path="social" element={<Social />} />
-				<Route path="profile" element={<Profile />} />
+				<Route path="profile/:username" element={<Profile />} />
 				<Route path="chat" element={<Chat />} />
 				<Route path="settings" element={<Settings />} />
 				<Route path="*" element={<Navigate replace to="play" />} />

--- a/front/src/style/Profile.css
+++ b/front/src/style/Profile.css
@@ -1,3 +1,7 @@
+.profile-loading {
+	margin: auto;
+}
+
 .profile-container {
 	border-radius: 20px;
 	background-color: lightgray;


### PR DESCRIPTION
Achievement has now an enum field !
Searching for a particular profile trigger a navigation change in the URL.

Small "not so great" behavior : entering a wrong profile name in the search bar still modify the URL. Otherwise, entering a wrong profile directly under `profile/wrongusername` kick back the user to the `play` page.